### PR TITLE
#164798259 Pagination support for articles

### DIFF
--- a/src/actions/getArticles.js
+++ b/src/actions/getArticles.js
@@ -1,14 +1,12 @@
 import axios from "axios";
 import { FETCH_ARTICLES_SUCCESS } from "./types";
 
-export const getArticlesAction = (kwargs = " ") => dispatch => {
-  return axios
-    .get(
-      "https://ah-backend-prime-staging.herokuapp.com/api/v1/articles/" + kwargs
-    )
-    .then(response => {
-      dispatch(fetchArticlesSuccess(response.data.results));
-    });
+export const getArticlesAction = (
+  url = "https://ah-backend-prime-staging.herokuapp.com/api/v1/articles/"
+) => async dispatch => {
+  return axios.get(url).then(response => {
+    dispatch(fetchArticlesSuccess(response.data));
+  });
 };
 
 const fetchArticlesSuccess = payload => {

--- a/src/components/home.js
+++ b/src/components/home.js
@@ -6,10 +6,23 @@ import { Link } from "react-router-dom";
 import { getArticlesAction } from "../actions/getArticles";
 
 export class Home extends Component {
-  componentDidMount() {
-    this.props.getArticlesAction();
+  constructor(props) {
+    super(props);
+    this.fetchNext = this.fetchNext.bind(this);
+    this.fetchPrevious = this.fetchPrevious.bind(this);
   }
-
+  componentDidMount() {
+    const { getArticlesAction } = this.props;
+    getArticlesAction();
+  }
+  fetchNext() {
+    const { next, getArticlesAction } = this.props;
+    getArticlesAction(next);
+  }
+  fetchPrevious() {
+    const { previous, getArticlesAction } = this.props;
+    getArticlesAction(previous);
+  }
   render() {
     const { articles } = this.props;
     const articleList = articles.length ? (
@@ -65,6 +78,7 @@ export class Home extends Component {
     ) : (
       <div>No Articles in Authors Haven Yet</div>
     );
+
     return (
       <div className="big-container">
         <div className="articles-top">
@@ -113,13 +127,29 @@ export class Home extends Component {
           <hr />
           {articleList}
         </div>
+        <div>
+          <button
+            className="btn btn-outline-success btn eian"
+            onClick={() => this.fetchPrevious()}
+          >
+            Previous
+          </button>{" "}
+          <button
+            className="btn btn-outline-success btn aken"
+            onClick={() => this.fetchNext()}
+          >
+            Next
+          </button>
+        </div>
       </div>
     );
   }
 }
 
 export const mapStateToProps = state => ({
-  articles: state.getArticlesReducer.articles
+  articles: state.getArticlesReducer.articles,
+  next: state.getArticlesReducer.next,
+  previous: state.getArticlesReducer.previous
 });
 
 export default connect(

--- a/src/reducers/getArticlesReducer.js
+++ b/src/reducers/getArticlesReducer.js
@@ -9,7 +9,9 @@ const getArticlesReducer = (state = initialState, action) => {
     case FETCH_ARTICLES_SUCCESS:
       return {
         ...state,
-        articles: action.payload
+        articles: action.payload.results,
+        next: action.payload.next,
+        previous: action.payload["previous"]
       };
     default:
       return state;

--- a/src/tests/__snapshots__/app.test.js.snap
+++ b/src/tests/__snapshots__/app.test.js.snap
@@ -465,6 +465,21 @@ exports[`App should render without crashing 1`] = `
           No Articles in Authors Haven Yet
         </div>
       </div>
+      <div>
+        <button
+          className="btn btn-outline-success btn eian"
+          onClick={[Function]}
+        >
+          Previous
+        </button>
+         
+        <button
+          className="btn btn-outline-success btn aken"
+          onClick={[Function]}
+        >
+          Next
+        </button>
+      </div>
     </div>
   </div>
 </div>

--- a/src/tests/actions/getArticlesAction.test.js
+++ b/src/tests/actions/getArticlesAction.test.js
@@ -24,13 +24,25 @@ describe("Action for getting Articles", () => {
       const requestM = moxios.requests.mostRecent();
       requestM.respondWith({
         status: 200,
-        response: { results: data.articles }
+        response: {
+          count: 75,
+          next:
+            "https://ah-backend-prime-staging.herokuapp.com/api/v1/articles/?page_size=2",
+          previous: null,
+          results: data.articles
+        }
       });
     });
     const expectedAction = [
       {
         type: FETCH_ARTICLES_SUCCESS,
-        payload: data.articles
+        payload: {
+          count: 75,
+          next:
+            "https://ah-backend-prime-staging.herokuapp.com/api/v1/articles/?page_size=2",
+          previous: null,
+          results: data.articles
+        }
       }
     ];
     return store.dispatch(getArticlesAction()).then(() => {

--- a/src/tests/components/articles.test.js
+++ b/src/tests/components/articles.test.js
@@ -10,7 +10,11 @@ import { CreateArticlePage } from "../../components/articles/createArticlePage";
 
 const props = {
   articles: data.articles,
-  getArticlesAction: jest.fn()
+  previous: "",
+  next: "",
+  getArticlesAction: jest.fn(),
+  fetchNext: jest.fn(),
+  fetchPrevious: jest.fn()
 };
 
 const props1 = {
@@ -23,9 +27,12 @@ const props1 = {
 };
 
 describe("Article Components", () => {
+  let homeWrapper;
+  beforeEach(() => {
+    homeWrapper = shallow(<Home {...props} />);
+  });
   it("should render the home page", () => {
-    const wrapper = shallow(<Home {...props} />);
-    expect(wrapper).toMatchSnapshot();
+    expect(homeWrapper).toMatchSnapshot();
   });
 
   it("renders the single article page", () => {
@@ -86,5 +93,29 @@ describe("Article Components", () => {
     wrapper.instance().onSubmit(event);
 
     expect(wrapper.instance().state.body).toEqual("This is the body");
+  });
+  it("should fetch next page", () => {
+    homeWrapper.instance().fetchNext();
+    expect(props.getArticlesAction).toHaveBeenCalled();
+  });
+  it("should fetch previous page", () => {
+    homeWrapper.instance().fetchPrevious();
+    expect(props.getArticlesAction).toHaveBeenCalled();
+  });
+  it("should simulate onclick for next page", () => {
+    homeWrapper
+      .find(".aken")
+      .at(0)
+      .simulate("click");
+
+    expect(props.fetchNext).toHaveBeenCalledTimes(0);
+  });
+  it("should simulate onclick for previous page", () => {
+    homeWrapper
+      .find(".eian")
+      .at(0)
+      .simulate("click");
+
+    expect(props.fetchPrevious).toHaveBeenCalledTimes(0);
   });
 });

--- a/src/tests/mock_data/moxios_mock.js
+++ b/src/tests/mock_data/moxios_mock.js
@@ -115,6 +115,153 @@ const data = {
     title: ["This field may not be blank."],
     description: ["This field may not be blank."],
     body: ["This field may not be blank."]
+  },
+  payload: {
+    results: [
+      {
+        id: 64,
+        author: {
+          username: "patritsfitz",
+          bio:
+            "This is my favorite song, I just dunno the words, but I still mess with you, you just ain't never heard. It goes like drop that thing. The day you don't drop that thing",
+          email: "patrick.okosu@andela.com",
+          full_name: "PATRICK FITZ",
+          image:
+            "https://firebasestorage.googleapis.com/v0/b/ah-frontend-prime.appspot.com/o/images%2F100_1655.JPG?alt=media&token=08c9e580-a9c2-4121-8fd1-c4e9a236e943",
+          followers_no: 3,
+          following_no: 0,
+          favorite_articles: "No favorite articles"
+        },
+        title: "kuhcf",
+        average_rating: 0,
+        description: "nkjyg",
+        body: "luy",
+        image:
+          "https://firebasestorage.googleapis.com/v0/b/ah-frontend-prime.appspot.com/o/images%2F20190315_141824.jpg?alt=media&token=b40739af-5c2d-4c81-8061-03ab1219383d",
+        createdAt: "2019-05-20T14:00:26.953431Z",
+        updatedAt: "2019-05-20T14:00:26.953478Z",
+        slug: "kuhcf-0x3f",
+        tagList: ["nj"],
+        likes: 0,
+        dislikes: 0,
+        reading_time: " less than a minute read",
+        favorite_count: 0
+      },
+      {
+        id: 3,
+        author: {
+          username: "patritsfitz",
+          bio:
+            "This is my favorite song, I just dunno the words, but I still mess with you, you just ain't never heard. It goes like drop that thing. The day you don't drop that thing",
+          email: "patrick.okosu@andela.com",
+          full_name: "PATRICK FITZ",
+          image:
+            "https://firebasestorage.googleapis.com/v0/b/ah-frontend-prime.appspot.com/o/images%2F100_1655.JPG?alt=media&token=08c9e580-a9c2-4121-8fd1-c4e9a236e943",
+          followers_no: 3,
+          following_no: 0,
+          favorite_articles: "No favorite articles"
+        },
+        title: "This is Kev and Fam",
+        average_rating: 0,
+        description: "Kev likes comics",
+        body: "Kev only make ting nice.",
+        image:
+          "https://pbs.twimg.com/profile_images/979164433430626305/ZYnzfyUD_400x400.jpg",
+        createdAt: "2019-05-14T17:15:19.146542Z",
+        updatedAt: "2019-05-14T17:33:25.200755Z",
+        slug: "this-is-kev-0x2",
+        tagList: [],
+        likes: 0,
+        dislikes: 0,
+        reading_time: " less than a minute read",
+        favorite_count: 0
+      },
+      {
+        id: 6,
+        author: {
+          username: "patritsfitz",
+          bio:
+            "This is my favorite song, I just dunno the words, but I still mess with you, you just ain't never heard. It goes like drop that thing. The day you don't drop that thing",
+          email: "patrick.okosu@andela.com",
+          full_name: "PATRICK FITZ",
+          image:
+            "https://firebasestorage.googleapis.com/v0/b/ah-frontend-prime.appspot.com/o/images%2F100_1655.JPG?alt=media&token=08c9e580-a9c2-4121-8fd1-c4e9a236e943",
+          followers_no: 3,
+          following_no: 0,
+          favorite_articles: "No favorite articles"
+        },
+        title: "lfksalkdkj",
+        average_rating: 0,
+        description: "fdsafsf",
+        body: "asffasdf",
+        image: "",
+        createdAt: "2019-05-15T14:58:07.354317Z",
+        updatedAt: "2019-05-15T14:58:07.354346Z",
+        slug: "lfksalkdkj-0x5",
+        tagList: ["sfdas"],
+        likes: 0,
+        dislikes: 0,
+        reading_time: " less than a minute read",
+        favorite_count: 0
+      },
+      {
+        id: 8,
+        author: {
+          username: "patritsfitz",
+          bio:
+            "This is my favorite song, I just dunno the words, but I still mess with you, you just ain't never heard. It goes like drop that thing. The day you don't drop that thing",
+          email: "patrick.okosu@andela.com",
+          full_name: "PATRICK FITZ",
+          image:
+            "https://firebasestorage.googleapis.com/v0/b/ah-frontend-prime.appspot.com/o/images%2F100_1655.JPG?alt=media&token=08c9e580-a9c2-4121-8fd1-c4e9a236e943",
+          followers_no: 3,
+          following_no: 0,
+          favorite_articles: "No favorite articles"
+        },
+        title: "This",
+        average_rating: 0,
+        description: "is an article",
+        body: "Don't get carried away",
+        image: "",
+        createdAt: "2019-05-16T09:07:17.176164Z",
+        updatedAt: "2019-05-16T09:07:17.176229Z",
+        slug: "this-0x7",
+        tagList: ["this", " is ", " andela"],
+        likes: 0,
+        dislikes: 0,
+        reading_time: " less than a minute read",
+        favorite_count: 0
+      },
+      {
+        id: 65,
+        author: {
+          username: "patritsfitz",
+          bio:
+            "This is my favorite song, I just dunno the words, but I still mess with you, you just ain't never heard. It goes like drop that thing. The day you don't drop that thing",
+          email: "patrick.okosu@andela.com",
+          full_name: "PATRICK FITZ",
+          image:
+            "https://firebasestorage.googleapis.com/v0/b/ah-frontend-prime.appspot.com/o/images%2F100_1655.JPG?alt=media&token=08c9e580-a9c2-4121-8fd1-c4e9a236e943",
+          followers_no: 3,
+          following_no: 0,
+          favorite_articles: "No favorite articles"
+        },
+        title: "Here Uganada",
+        average_rating: 0,
+        description: "Am a cool guy",
+        body: "Yeah as i have alreay said ,am a cool guy",
+        image:
+          "https://firebasestorage.googleapis.com/v0/b/ah-frontend-prime.appspot.com/o/images%2F20190314_180238.jpg?alt=media&token=ae427495-859a-47ca-a3b4-aee878aadb93",
+        createdAt: "2019-05-20T14:02:32.935738Z",
+        updatedAt: "2019-05-20T14:02:32.935793Z",
+        slug: "here-uganada-0x40",
+        tagList: ["test", "home"],
+        likes: 0,
+        dislikes: 0,
+        reading_time: " less than a minute read",
+        favorite_count: 0
+      }
+    ]
   }
 };
 

--- a/src/tests/reducers/getArticlesReducer.test.js
+++ b/src/tests/reducers/getArticlesReducer.test.js
@@ -1,6 +1,6 @@
 import getArticlesReducer from "../../reducers/getArticlesReducer";
 import { FETCH_ARTICLES_SUCCESS } from "../../actions/types";
-import articles from "../mock_data/moxios_mock";
+import data from "../mock_data/moxios_mock";
 
 describe("App", () => {
   const initialState = {
@@ -14,8 +14,13 @@ describe("App", () => {
   it("Should handle reducers after getting articles", () => {
     const newState = getArticlesReducer(initialState, {
       type: FETCH_ARTICLES_SUCCESS,
-      payload: articles
+      payload: {
+        results: data.articles
+      }
     });
-    expect(newState).toEqual({ ...initialState, articles: articles });
+    expect(newState).toEqual({
+      ...initialState,
+      articles: data.articles
+    });
   });
 });


### PR DESCRIPTION
#### What does this PR do?
- Add pagination to our articles to make article traversal easier
#### Description of tasks to be completed.
- Add pagination support for articles
- Modify get articles reducer to cater for next and previous pages
- Add button in the home page that traverses the next and previous pages of the articles
- Add tests for functionality
#### How should this be manually tested?
- Visit the deployed application page
- On the home is a collection of articles that can be accessed by authenticated and non-authenticated users.
- Below the articles are the `Next` and `Previous` buttons that take you to the next and previous page respectively.

#### Any background context you want to provide?
- N/A
#### What are the relevant pivotal tracker stories?
[#164798259](https://www.pivotaltracker.com/story/show/164798259)

#### Screenshots(if appropriate)
- Articles page with pagination buttons
![image](https://user-images.githubusercontent.com/36891299/58256396-9c65ac80-7d77-11e9-89cd-3980df8e6e38.png)


